### PR TITLE
UI-6657 - Improve migration script warnings

### DIFF
--- a/src/migrateTextEditor.test.ts
+++ b/src/migrateTextEditor.test.ts
@@ -3,7 +3,15 @@ import { legacyTextEditor } from "./__test_resources__/legacyTextEditor";
 
 describe("migrateTextEditor", () => {
   it("returns the ActiveUI5 Text Editor widget state corresponding to the given ActiveUI4 Rich Text Editor widget state", () => {
-    expect(migrateTextEditor(legacyTextEditor)).toMatchInlineSnapshot(`
+    const warn = console.warn;
+    console.warn = jest.fn();
+    try {
+      const migratedTextEditor = migrateTextEditor(legacyTextEditor);
+      expect(console.warn).toHaveBeenCalledTimes(1);
+      expect(console.warn).toHaveBeenCalledWith(
+        "The `text-editor` widget is not part of the plugin registry in the ActiveUI 5 starter.\nMake sure to add it in your project.\n See https://activeviam.com/activeui/documentation/5.0.3/docs/tutorial/yourFirstCustomWidget#extend-activeui."
+      );
+      expect(migratedTextEditor).toMatchInlineSnapshot(`
       Object {
         "displayMode": "view",
         "name": "Text Editor",
@@ -21,5 +29,8 @@ describe("migrateTextEditor", () => {
         "widgetKey": "text-editor",
       }
     `);
+    } finally {
+      console.warn = warn;
+    }
   });
 });

--- a/src/migrateTextEditor.ts
+++ b/src/migrateTextEditor.ts
@@ -5,8 +5,12 @@ import { TextEditorWidgetState } from "@activeviam/plugin-widget-text-editor";
  * Returns the converted Text Editor widget state, ready to be used by ActiveUI 5.
  */
 export function migrateTextEditor(
-  legacyTextEditorState: LegacyWidgetState,
+  legacyTextEditorState: LegacyWidgetState
 ): TextEditorWidgetState<"serialized"> {
+  // eslint-disable-next-line no-console
+  console.warn(
+    "The `text-editor` widget is not part of the plugin registry in the ActiveUI 5 starter.\nMake sure to add it in your project.\n See https://activeviam.com/activeui/documentation/5.0.3/docs/tutorial/yourFirstCustomWidget#extend-activeui."
+  );
   const { content: text, editingMode } =
     legacyTextEditorState.value?.body ?? {};
   const displayMode = editingMode === "edit" ? "edit" : "view";

--- a/src/migrateUIFolder.ts
+++ b/src/migrateUIFolder.ts
@@ -295,7 +295,7 @@ export function migrateUIFolder(
         } catch (error) {
           // eslint-disable-next-line no-console
           console.error(
-            `An error occurred during the migration of filter ${id} ("${bookmark.name}"). Ignoring this filter. Error:\n${error.message}`
+            `An error occurred during the migration of filter ${id} ("${bookmark.name}"). Ignoring this filter. Error:\n${error.stack}`
           );
         }
       } else if (bookmark.value.containerKey === "dashboard") {
@@ -311,7 +311,7 @@ export function migrateUIFolder(
         } catch (error) {
           // eslint-disable-next-line no-console
           console.error(
-            `An error occurred during the migration of dashboard ${id} ("${bookmark.name}"). Ignoring this dashboard. Error:\n${error.message}`
+            `An error occurred during the migration of dashboard ${id} ("${bookmark.name}"). Ignoring this dashboard. Error:\n${error.stack}`
           );
         }
       } else {
@@ -329,7 +329,7 @@ export function migrateUIFolder(
         } catch (error) {
           // eslint-disable-next-line no-console
           console.error(
-            `An error occurred during the migration of widget ${id} ("${bookmark.name}"). Ignoring this widget. Error:\n${error.message}`
+            `An error occurred during the migration of widget ${id} ("${bookmark.name}"). Ignoring this widget. Error:\n${error.stack}`
           );
         }
       }

--- a/src/migrateWidget.test.ts
+++ b/src/migrateWidget.test.ts
@@ -13,8 +13,7 @@ describe("migrateWidget", () => {
         body: {
           query: {
             updateMode: "once",
-            mdx:
-              "SELECT NON EMPTY Crossjoin([Booking].[Desk].[LegalEntity].Members, [Currency].[Currency].[Currency].Members) ON ROWS, NON EMPTY [Measures].[contributors.COUNT] ON COLUMNS FROM [EquityDerivativesCube]",
+            mdx: "SELECT NON EMPTY Crossjoin([Booking].[Desk].[LegalEntity].Members, [Currency].[Currency].[Currency].Members) ON ROWS, NON EMPTY [Measures].[contributors.COUNT] ON COLUMNS FROM [EquityDerivativesCube]",
           },
           configuration: {
             type: "plotly-line-chart",
@@ -75,11 +74,12 @@ describe("migrateWidget", () => {
       expect(migrateWidget(legacyWidgetState, servers)).toMatchInlineSnapshot(`
         Object {
           "name": "Untitled page context values",
+          "widgetKey": "context-values",
         }
       `);
       expect(console.warn).toHaveBeenCalledTimes(1);
       expect(console.warn).toHaveBeenCalledWith(
-        `Unsupported widgetKey: "context-values". The widget ("Untitled page context values") will be copied as is. It might not work correctly in ActiveUI5.`,
+        `Unsupported widgetKey: "context-values". The widget ("Untitled page context values") will be copied as is. It will most likely not work correctly in ActiveUI 5.`
       );
     } finally {
       console.warn = warn;

--- a/src/migrateWidget.ts
+++ b/src/migrateWidget.ts
@@ -14,7 +14,7 @@ import { migrateTextEditor } from "./migrateTextEditor";
  */
 export function migrateWidget(
   legacyWidgetState: LegacyWidgetState,
-  servers: { [serverKey: string]: { dataModel: DataModel; url: string } },
+  servers: { [serverKey: string]: { dataModel: DataModel; url: string } }
 ): AWidgetState<"serialized"> {
   switch (legacyWidgetState.value.containerKey) {
     case "chart":
@@ -33,11 +33,12 @@ export function migrateWidget(
     default:
       // eslint-disable-next-line no-console
       console.warn(
-        `Unsupported widgetKey: "${legacyWidgetState.value.containerKey}". The widget ("${legacyWidgetState.name}") will be copied as is. It might not work correctly in ActiveUI5.`,
+        `Unsupported widgetKey: "${legacyWidgetState.value.containerKey}". The widget ("${legacyWidgetState.name}") will be copied as is. It will most likely not work correctly in ActiveUI 5.`
       );
       return {
-        name: legacyWidgetState?.name,
         ...legacyWidgetState?.value?.body,
+        name: legacyWidgetState?.name,
+        widgetKey: legacyWidgetState.value.containerKey,
       };
   }
 }


### PR DESCRIPTION
- The full error stack is logged when an error is thrown within `migrateUIFolder`
- The `widgetKey` is added to the migrated state of custom widgets, so that a clear error ends up being thrown in the UI hinting that the widget plugin should be defined and added to the plugin registry.
- A warning is logged to let users know that they should add the `text-editor` plugin to their registry. 