### PR TITLE
UI-6655 - Mark CLI options as mandatory

### DIFF
--- a/src/cli/bin.ts
+++ b/src/cli/bin.ts
@@ -10,17 +10,19 @@ yargs
       args.option("input-path", {
         alias: "i",
         string: true,
+        demandOption: true,
         desc: "The path to the JSON export of the ActiveUI 4 /ui folder.",
       });
       args.option("output-path", {
         alias: "o",
         string: true,
-        desc:
-          "The path to the migrated file, ready to be imported into the Content Server and used in ActiveUI 5.",
+        demandOption: true,
+        desc: "The path to the migrated file, ready to be imported into the Content Server and used in ActiveUI 5.",
       });
       args.option("servers-path", {
         alias: "s",
         string: true,
+        demandOption: true,
         desc: "The path to the JSON file holding the servers information.",
       });
     },
@@ -37,7 +39,7 @@ yargs
       const servers = await fs.readJSON(serversPath);
       const migratedUIFolder = migrateUIFolder(legacyUIFolder, servers);
       await fs.writeJSON(outputPath, migratedUIFolder, { spaces: 2 });
-    },
+    }
   )
   .demandCommand(1)
   .strict()


### PR DESCRIPTION
It's all in the title.
Now, if you don't specify the `--servers-path` option, you will get a clear message saying that it's missing:

![image](https://user-images.githubusercontent.com/29061952/138113875-a749b1ad-942d-4ffa-ac27-bc511f6a56e3.png)
