### PR TITLE
UI-8532 - Take hidden columns into account during table migrations from 4.3 to 5.0

### DIFF
--- a/src/4.3_to_5.0/__test_resources__/legacyPivotTableWithCrossjoinOnColumnsAndHiddenColumns.ts
+++ b/src/4.3_to_5.0/__test_resources__/legacyPivotTableWithCrossjoinOnColumnsAndHiddenColumns.ts
@@ -1,0 +1,23 @@
+/**
+ * The state of a legacy pivot table with Dates, LegalEntities, pnl.FOREX and pnl.SUM on columns and one column is hidden.
+ */
+export const legacyPivotTableWithCrossjoinOnColumnsAndHiddenColumns = {
+  name: "Untitled Pivot Table",
+  type: "container",
+  value: {
+    body: {
+      mdx: "SELECT NON EMPTY Crossjoin([Time].[HistoricalDates].[AsOfDate].Members, Hierarchize(DrilldownLevel([Booking].[Desk].[ALL].[AllMember])), {[Measures].[pnl.FOREX], [Measures].[pnl.SUM]}) ON COLUMNS, NON EMPTY Hierarchize(DrilldownLevel([Currency].[Currency].[ALL].[AllMember])) ON ROWS FROM [EquityDerivativesCube] CELL PROPERTIES VALUE, FORMATTED_VALUE, BACK_COLOR, FORE_COLOR, FONT_FLAGS",
+      configuration: {
+        tabular: {
+          columns: [
+            {
+              key: "([Time].[HistoricalDates].[AsOfDate].[2023-09-05],[Booking].[Desk].[ALL].[AllMember].[LegalEntityA],[Measures].[pnl.FOREX])",
+              hide: true,
+            },
+          ],
+        },
+      },
+    },
+    containerKey: "pivot-table",
+  },
+};

--- a/src/4.3_to_5.0/__test_resources__/legacyPivotTableWithCrossjoinOnColumnsAndHiddenColumns.ts
+++ b/src/4.3_to_5.0/__test_resources__/legacyPivotTableWithCrossjoinOnColumnsAndHiddenColumns.ts
@@ -1,23 +1,26 @@
+import { LegacyWidgetState } from "../migration.types";
+
 /**
  * The state of a legacy pivot table with Dates, LegalEntities, pnl.FOREX and pnl.SUM on columns and one column is hidden.
  */
-export const legacyPivotTableWithCrossjoinOnColumnsAndHiddenColumns = {
-  name: "Untitled Pivot Table",
-  type: "container",
-  value: {
-    body: {
-      mdx: "SELECT NON EMPTY Crossjoin([Time].[HistoricalDates].[AsOfDate].Members, Hierarchize(DrilldownLevel([Booking].[Desk].[ALL].[AllMember])), {[Measures].[pnl.FOREX], [Measures].[pnl.SUM]}) ON COLUMNS, NON EMPTY Hierarchize(DrilldownLevel([Currency].[Currency].[ALL].[AllMember])) ON ROWS FROM [EquityDerivativesCube] CELL PROPERTIES VALUE, FORMATTED_VALUE, BACK_COLOR, FORE_COLOR, FONT_FLAGS",
-      configuration: {
-        tabular: {
-          columns: [
-            {
-              key: "([Time].[HistoricalDates].[AsOfDate].[2023-09-05],[Booking].[Desk].[ALL].[AllMember].[LegalEntityA],[Measures].[pnl.FOREX])",
-              hide: true,
-            },
-          ],
+export const legacyPivotTableWithCrossjoinOnColumnsAndHiddenColumns: LegacyWidgetState =
+  {
+    name: "Untitled Pivot Table",
+    type: "container",
+    value: {
+      body: {
+        mdx: "SELECT NON EMPTY Crossjoin([Time].[HistoricalDates].[AsOfDate].Members, Hierarchize(DrilldownLevel([Booking].[Desk].[ALL].[AllMember])), {[Measures].[pnl.FOREX], [Measures].[pnl.SUM]}) ON COLUMNS, NON EMPTY Hierarchize(DrilldownLevel([Currency].[Currency].[ALL].[AllMember])) ON ROWS FROM [EquityDerivativesCube] CELL PROPERTIES VALUE, FORMATTED_VALUE, BACK_COLOR, FORE_COLOR, FONT_FLAGS",
+        configuration: {
+          tabular: {
+            columns: [
+              {
+                key: "([Time].[HistoricalDates].[AsOfDate].[2023-09-05],[Booking].[Desk].[ALL].[AllMember].[LegalEntityA],[Measures].[pnl.FOREX])",
+                hide: true,
+              },
+            ],
+          },
         },
       },
+      containerKey: "pivot-table",
     },
-    containerKey: "pivot-table",
-  },
-};
+  };

--- a/src/4.3_to_5.0/__test_resources__/legacyPivotTableWithHiddenColumns.ts
+++ b/src/4.3_to_5.0/__test_resources__/legacyPivotTableWithHiddenColumns.ts
@@ -1,0 +1,23 @@
+/**
+ * The state of a legacy pivot table with dates on columns and one column is hidden.
+ */
+export const legacyPivotTableWithHiddenColumns = {
+  name: "Untitled Pivot Table",
+  type: "container",
+  value: {
+    body: {
+      mdx: "SELECT NON EMPTY [Time].[HistoricalDates].[AsOfDate].Members ON COLUMNS, NON EMPTY Hierarchize(DrilldownLevel([Currency].[Currency].[ALL].[AllMember])) ON ROWS FROM [EquityDerivativesCube] CELL PROPERTIES VALUE, FORMATTED_VALUE, BACK_COLOR, FORE_COLOR, FONT_FLAGS",
+      configuration: {
+        tabular: {
+          columns: [
+            {
+              key: "[Time].[HistoricalDates].[AsOfDate].[2023-09-05]",
+              hide: true,
+            },
+          ],
+        },
+      },
+    },
+    containerKey: "pivot-table",
+  },
+};

--- a/src/4.3_to_5.0/__test_resources__/legacyPivotTableWithHiddenColumns.ts
+++ b/src/4.3_to_5.0/__test_resources__/legacyPivotTableWithHiddenColumns.ts
@@ -1,7 +1,9 @@
+import { LegacyWidgetState } from "../migration.types";
+
 /**
  * The state of a legacy pivot table with dates on columns and one column is hidden.
  */
-export const legacyPivotTableWithHiddenColumns = {
+export const legacyPivotTableWithHiddenColumns: LegacyWidgetState = {
   name: "Untitled Pivot Table",
   type: "container",
   value: {

--- a/src/4.3_to_5.0/__test_resources__/legacyTableWithHiddenColumns.ts
+++ b/src/4.3_to_5.0/__test_resources__/legacyTableWithHiddenColumns.ts
@@ -1,8 +1,10 @@
+import { LegacyWidgetState } from "../migration.types";
+
 /**
  * The state of a legacy table with Currency and City on rows and contributors.COUNT on columns.
  * The "City" column is hidden.
  */
-export const legacyTableWithHiddenColumns = {
+export const legacyTableWithHiddenColumns: LegacyWidgetState = {
   type: "container",
   name: "Untitled Tabular View",
   value: {

--- a/src/4.3_to_5.0/__test_resources__/legacyTableWithHiddenColumns.ts
+++ b/src/4.3_to_5.0/__test_resources__/legacyTableWithHiddenColumns.ts
@@ -1,0 +1,24 @@
+/**
+ * The state of a legacy table with Currency and City on rows and contributors.COUNT on columns.
+ * The "City" column is hidden.
+ */
+export const legacyTableWithHiddenColumns = {
+  type: "container",
+  name: "Untitled Tabular View",
+  value: {
+    body: {
+      mdx: "SELECT NON EMPTY Crossjoin([Currency].[Currency].[Currency].Members, [Geography].[City].[City].Members) ON ROWS, [Measures].[contributors.COUNT] ON COLUMNS FROM [EquityDerivativesCube] CELL PROPERTIES VALUE, FORMATTED_VALUE, BACK_COLOR, FORE_COLOR, FONT_FLAGS",
+      configuration: {
+        tabular: {
+          columns: [
+            {
+              key: "[Geography].[City].[City]",
+              hide: true,
+            },
+          ],
+        },
+      },
+    },
+    containerKey: "tabular-view",
+  },
+};

--- a/src/4.3_to_5.0/_getHiddenColumnKeys.test.ts
+++ b/src/4.3_to_5.0/_getHiddenColumnKeys.test.ts
@@ -1,0 +1,37 @@
+import { legacyPivotTableWithCrossjoinOnColumnsAndHiddenColumns } from "./__test_resources__/legacyPivotTableWithCrossjoinOnColumnsAndHiddenColumns";
+import { legacyPivotTableWithHiddenColumns } from "./__test_resources__/legacyPivotTableWithHiddenColumns";
+import { legacyTableWithHiddenColumns } from "./__test_resources__/legacyTableWithHiddenColumns";
+import { _getHiddenColumnKeys } from "./_getHiddenColumnKeys";
+
+describe("_getHiddenColumnKeys", () => {
+  it("returns the hidden column keys in a table with a static header column hidden", () => {
+    const hiddenColumnKeys = _getHiddenColumnKeys(legacyTableWithHiddenColumns);
+    expect(hiddenColumnKeys).toMatchInlineSnapshot(`
+      [
+        "[Geography].[City].[City]",
+      ]
+    `);
+  });
+
+  it("returns the hidden column keys in a pivot table with a body column hidden", () => {
+    const hiddenColumnKeys = _getHiddenColumnKeys(
+      legacyPivotTableWithHiddenColumns,
+    );
+    expect(hiddenColumnKeys).toMatchInlineSnapshot(`
+      [
+        "[Time].[HistoricalDates].[AsOfDate].[2023-09-05]",
+      ]
+    `);
+  });
+
+  it("returns the hidden column keys in a table with a crossjoin on columns and a body column hidden", () => {
+    const hiddenColumnKeys = _getHiddenColumnKeys(
+      legacyPivotTableWithCrossjoinOnColumnsAndHiddenColumns,
+    );
+    expect(hiddenColumnKeys).toMatchInlineSnapshot(`
+      [
+        "[Time].[HistoricalDates].[AsOfDate].[2023-09-05],[Booking].[Desk].[ALL].[AllMember].[LegalEntityA],[Measures].[pnl.FOREX]",
+      ]
+    `);
+  });
+});

--- a/src/4.3_to_5.0/_getHiddenColumnKeys.ts
+++ b/src/4.3_to_5.0/_getHiddenColumnKeys.ts
@@ -1,0 +1,23 @@
+import { LegacyWidgetState } from "./migration.types";
+
+/**
+ * Returns the keys identifying the hidden columns in `legacyTableState`.
+ */
+export function _getHiddenColumnKeys(
+  legacyTableState: LegacyWidgetState,
+): string[] | undefined {
+  const columns: { key: string; hide?: boolean }[] | undefined =
+    legacyTableState?.value?.body?.configuration?.tabular?.columns;
+
+  if (!columns) {
+    return;
+  }
+
+  const hiddenColumnKeys = columns
+    .filter(({ hide }) => hide === true)
+    .map(({ key }) =>
+      key.startsWith("(") && key.endsWith(")") ? key.slice(1, -1) : key,
+    );
+
+  return hiddenColumnKeys;
+}

--- a/src/4.3_to_5.0/migrateTable.test.ts
+++ b/src/4.3_to_5.0/migrateTable.test.ts
@@ -11,6 +11,7 @@ import { legacyTable } from "./__test_resources__/legacyTable";
 import { legacyTabularView } from "./__test_resources__/legacyTabularView";
 import { legacyTreeTable } from "./__test_resources__/legacyTreeTable";
 import { servers } from "./__test_resources__/servers";
+import { legacyTableWithHiddenColumns } from "./__test_resources__/legacyTableWithHiddenColumns";
 
 describe("migrateTable", () => {
   it("migrates a tree table widget", () => {
@@ -237,6 +238,19 @@ describe("migrateTable", () => {
         ) ON ROWS
         FROM [EquityDerivativesCube]
         CELL PROPERTIES VALUE, FORMATTED_VALUE, BACK_COLOR, FORE_COLOR, FONT_FLAGS"
+    `);
+  });
+
+  it("migrates a table with hidden columns", () => {
+    const migratedTableState = migrateTable(
+      legacyTableWithHiddenColumns,
+      servers,
+    ) as TableWidgetState<"serialized">;
+
+    expect(migratedTableState.hiddenColumns).toMatchInlineSnapshot(`
+      [
+        "[Geography].[City].[City]",
+      ]
     `);
   });
 });

--- a/src/4.3_to_5.0/migrateTable.ts
+++ b/src/4.3_to_5.0/migrateTable.ts
@@ -17,6 +17,7 @@ import { _getQueryInLegacyWidgetState } from "./_getQueryInLegacyWidgetState";
 import { _getTargetCubeFromServerUrl } from "./_getTargetCubeFromServerUrl";
 import { _migrateQuery } from "./_migrateQuery";
 import { _migrateTableColumnWidths } from "./_migrateTableColumnWidths";
+import { _getHiddenColumnKeys } from "./_getHiddenColumnKeys";
 
 /**
  * Returns the converted table widget state, ready to be used by ActiveUI 5.
@@ -87,6 +88,12 @@ export function migrateTable(
     widgetKey: widgetPlugin.key,
     columnWidths,
   };
+
+  const hiddenColumnKeys = _getHiddenColumnKeys(legacyTableState);
+
+  if (hiddenColumnKeys && hiddenColumnKeys.length > 0) {
+    migratedWidgetState.hiddenColumns = hiddenColumnKeys;
+  }
 
   const serializedWidgetState = serializeWidgetState(migratedWidgetState);
 


### PR DESCRIPTION
Before this PR, hidden columns in AUI 4.3 would not be hidden post-migration, when the table is viewed in AUI 5.0.

This PR fixes it.