### PR TITLE
UI-8812 - Fix 'Cannot read properties of undefined (reading 'type')' error when passing the --tree-column-width option

### DIFF
--- a/src/4.3_to_5.0/_migrateTableColumnWidths.ts
+++ b/src/4.3_to_5.0/_migrateTableColumnWidths.ts
@@ -42,10 +42,13 @@ export function _migrateTableColumnWidths({
       cube,
     });
 
-    const [baseWidth, maxLevelMultiplier] = treeTableColumnWidth;
-    columnWidths[columnKey] = baseWidth + levelDepthOnRows * maxLevelMultiplier;
+    if (columnKey !== undefined) {
+      const [baseWidth, maxLevelMultiplier] = treeTableColumnWidth;
+      columnWidths[columnKey] =
+        baseWidth + levelDepthOnRows * maxLevelMultiplier;
 
-    return columnWidths;
+      return columnWidths;
+    }
   }
 
   legacyColumns.forEach(({ key, width }) => {

--- a/src/4.3_to_5.0/getTreeColumnKey.ts
+++ b/src/4.3_to_5.0/getTreeColumnKey.ts
@@ -15,14 +15,21 @@ export function getTreeColumnKey({
 }: {
   mapping: DataVisualizationWidgetMapping;
   cube: Cube;
-}): string {
-  switch (mapping.rows[0].type) {
+}): string | undefined {
+  if (mapping.rows.length === 0) {
+    return undefined;
+  }
+
+  const firstFieldOnRows = mapping.rows[0];
+
+  switch (firstFieldOnRows.type) {
     case "hierarchy": {
+      const { dimensionName, hierarchyName } = firstFieldOnRows;
       const hierarchy = mapping.rows[0]
         ? getHierarchy(
             {
-              dimensionName: mapping.rows[0].dimensionName,
-              hierarchyName: mapping.rows[0].hierarchyName,
+              dimensionName,
+              hierarchyName,
             },
             cube,
           )
@@ -34,25 +41,23 @@ export function getTreeColumnKey({
         firstLevelName && mapping.rows[0]
           ? getLevel(
               {
-                dimensionName: mapping.rows[0].dimensionName,
-                hierarchyName: mapping.rows[0].hierarchyName,
+                dimensionName,
+                hierarchyName,
                 levelName: firstLevelName.name,
               },
               cube,
             )
           : undefined;
 
-      const { dimensionName, hierarchyName } = mapping.rows[0];
-
       const levelName = firstLevel
         ? firstLevel.name
-        : mapping.rows[0].levelName;
+        : firstFieldOnRows.levelName;
 
       return quote(dimensionName, hierarchyName, levelName);
     }
     case "compositeHierarchy": {
       const { dimensionName, hierarchyName, levelName } =
-        mapping.rows[0].hierarchies[0];
+        firstFieldOnRows.hierarchies[0];
       return quote(dimensionName, hierarchyName, levelName);
     }
     case "allMeasures": {


### PR DESCRIPTION
This error is thrown when the user passes the option `--tree-column-width` but some of their widgets don' have any field on rows.

This PR fixes it.