### PR TITLE
UI-8859 - Fix error thrown when all widgets but one are removed from a page

### DIFF
--- a/src/4.3_to_5.0/migrateDashboard.ts
+++ b/src/4.3_to_5.0/migrateDashboard.ts
@@ -79,6 +79,8 @@ export function migrateDashboard(
           ...(keysOfLeavesToRemove[pageKey] ?? []),
           leafKey,
         ];
+        // Necessary for the `removeWidget` function called below to work correctly.
+        content[leafKey] = {};
         _addWidgetErrorToReport(
           errorReport,
           new WidgetFlaggedForRemovalError(widgetPluginKey),


### PR DESCRIPTION
This is a blocker for the Santander upgrade (from 4.3 to 5.1).
The error is not mentioned in the ticket, but the scenario is well enough described that I could reproduce it with a unit test.

The cause is that during the 4.3 -> 5.0 migration, we would not add anything under `page.content` for widgets that would be removed anyway. The problem is that the widget removal logic depends on it being present both in layout and [in content](https://github.com/activeviam/atoti-ui/blob/6d19eadb48bd756280c0208f078ed8805ad873b4/packages/dashboard-base/src/utils/removeWidget.ts#L67).

This PR fixes the bug and should unlock the Santander upgrade.