### PR TITLE
UI-8803 - Support namespaces in XML calculated members

### DIFF
--- a/src/4.3_to_5.0/__snapshots__/getCalculatedMeasures.test.ts.snap
+++ b/src/4.3_to_5.0/__snapshots__/getCalculatedMeasures.test.ts.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`getCalculatedMeasures parses an XML calculated measure with a namespace 1`] = `
+[
+  {
+    "expression": "[Measures].[deltaMTM]",
+    "formatStringExpression": ""#,###,,"",
+    "owners": [
+      "43890025",
+    ],
+    "readers": [
+      "43890025",
+    ],
+    "uniqueName": "[Measures].[CC Impact MtM]",
+  },
+]
+`;
+
 exports[`getCalculatedMeasures returns the parsed calculated measure objects 1`] = `
 [
   {

--- a/src/4.3_to_5.0/getCalculatedMeasures.test.ts
+++ b/src/4.3_to_5.0/getCalculatedMeasures.test.ts
@@ -53,4 +53,45 @@ describe("getCalculatedMeasures", () => {
 
     expect(result).toMatchSnapshot();
   });
+
+  // https://activeviam.atlassian.net/browse/UI-8803
+  it("parses an XML calculated measure with a namespace", async () => {
+    // The "calculateMember" tag has a namespace: "ns2".
+    const legacyCalculatedMeasuresFolder = {
+      entry: {
+        isDirectory: true,
+        owners: ["ROLE_CS_ROOT"],
+        readers: ["ROLE_CS_ROOT"],
+      },
+      children: {
+        EquityDerivativesCube: {
+          entry: {
+            isDirectory: true,
+            owners: ["ROLE_CS_ROOT"],
+            readers: ["ROLE_CS_ROOT"],
+          },
+
+          children: {
+            "[Measures].[CC Impact MtM]": {
+              entry: {
+                content:
+                  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<ns2:calculatedMember expression="[Measures].[deltaMTM]" formatStringExpression="&quot;#,###,,&quot;" uniqueName="[Measures].[CC Impact MtM]" xmlns:ns2="http://www.quartetfs.com">\n    <ns2:additionalProperties/>\n</ns2:calculatedMember>\n',
+                isDirectory: false,
+                owners: ["43890025"],
+                readers: ["43890025"],
+                timestamp: 1569424639841,
+                lastEditor: "43890025",
+                canRead: true,
+                canWrite: true,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = await getCalculatedMeasures(legacyCalculatedMeasuresFolder);
+
+    expect(result).toMatchSnapshot();
+  });
 });

--- a/src/4.3_to_5.0/getCalculatedMeasures.ts
+++ b/src/4.3_to_5.0/getCalculatedMeasures.ts
@@ -2,6 +2,7 @@ import { ContentRecord } from "@activeviam/activeui-sdk-5.0";
 import xml2js from "xml2js";
 import _flatMap from "lodash/flatMap";
 import { LegacyCalculatedMeasure } from "./migrateCalculatedMeasures";
+import { stripPrefix } from "xml2js/lib/processors";
 
 /**
  * Extracts and parses the XML calculated measure objects from the /pivot/entitlements/cm folder.
@@ -9,7 +10,7 @@ import { LegacyCalculatedMeasure } from "./migrateCalculatedMeasures";
 export const getCalculatedMeasures = async (
   calculatedMeasuresFolder: ContentRecord,
 ): Promise<LegacyCalculatedMeasure[]> => {
-  const parser = new xml2js.Parser();
+  const parser = new xml2js.Parser({ tagNameProcessors: [stripPrefix] });
 
   const calculatedMeasures: LegacyCalculatedMeasure[] = [];
 


### PR DESCRIPTION
See UI-8803, and the added test: the problem is that the `calculatedMember` tag in the customer's XML is prefixed with a namespace (`ns2`).
Adding a [tag processor](https://www.npmjs.com/package/xml2js#processing-attribute-tag-names-and-values) allows to remove it from the parsed JSON.

Note that when migrating all the way from 4.3 to 5.1, then:
- during 4.3 to 5.0, the prefix is removed
- it it not added again in 5.0 to 5.1

I honestly think it's fine, and would prefer for clients to report an issue before trying to preserve it.
For example, in this example from the customer, [`ns2` is actually a dummy namespace that should only be used in test cases](https://www.w3.org/XML/2008/xsdl-exx/ns2).