### PR TITLE
UI-9384 - Preserve KPI titles when migrated KPI widgets from 4.3 to 5.0

### DIFF
--- a/src/4.3_to_5.0/__test_resources__/legacyComparisonValues.ts
+++ b/src/4.3_to_5.0/__test_resources__/legacyComparisonValues.ts
@@ -9,8 +9,7 @@ export const legacyComparisonValues = {
     showTitleBar: true,
     body: {
       serverUrl: "http://localhost:9090",
-      mdx:
-        "SELECT NON EMPTY Hierarchize(DrilldownLevel([Currency].[Currency].[ALL].[AllMember])) ON ROWS, NON EMPTY [Measures].[pnl.FOREX] ON COLUMNS, {[Booking].[Desk].[ALL].[AllMember].[LegalEntityA], [Booking].[Desk].[ALL].[AllMember].[LegalEntityB]} ON PAGES FROM [EquityDerivativesCube] CELL PROPERTIES VALUE, FORMATTED_VALUE, BACK_COLOR, FORE_COLOR, FONT_FLAGS",
+      mdx: "SELECT NON EMPTY Hierarchize(DrilldownLevel([Currency].[Currency].[ALL].[AllMember])) ON ROWS, NON EMPTY [Measures].[pnl.FOREX] ON COLUMNS, {[Booking].[Desk].[ALL].[AllMember].[LegalEntityA], [Booking].[Desk].[ALL].[AllMember].[LegalEntityB]} ON PAGES FROM [EquityDerivativesCube] CELL PROPERTIES VALUE, FORMATTED_VALUE, BACK_COLOR, FORE_COLOR, FONT_FLAGS",
       contextValues: {},
       updateMode: "once",
       ranges: {
@@ -24,7 +23,13 @@ export const legacyComparisonValues = {
         },
       },
       configuration: {
-        featuredValues: {},
+        featuredValues: {
+          locations: {
+            "[Currency].[Currency].[AllMember].[GBP],[Measures].[pnl.FOREX]": {
+              title: "Hello World",
+            },
+          },
+        },
       },
     },
     containerKey: "featured-values",

--- a/src/4.3_to_5.0/__test_resources__/legacyKpi.ts
+++ b/src/4.3_to_5.0/__test_resources__/legacyKpi.ts
@@ -29,7 +29,15 @@ export const legacyKpi: LegacyWidgetState = {
         },
       },
       configuration: {
-        featuredValues: {},
+        featuredValues: {
+          locations: {
+            // "EUR, USD" is not a member of the sandbox, but it is used here to check that the script supports member names including ",".
+            "[Currency].[Currency].[AllMember].[EUR, USD],[Measures].[contributors.COUNT]":
+              {
+                title: "Hello World",
+              },
+          },
+        },
       },
     },
     containerKey: "featured-values",

--- a/src/4.3_to_5.0/getMigratedKpiTitles.test.ts
+++ b/src/4.3_to_5.0/getMigratedKpiTitles.test.ts
@@ -1,0 +1,30 @@
+import { dataModelsForTests } from "@activeviam/data-model-5.0";
+import { getMigratedKpiTitles } from "./getMigratedKpiTitles";
+import { legacyKpi } from "./__test_resources__/legacyKpi";
+
+const cube = dataModelsForTests.sandbox.catalogs[0].cubes[0];
+
+describe("getMigratedKpiTitles", () => {
+  it("returns the migrated KPI titles corresponding to the legacy KPI state, ready to be used in Atoti UI 5.0", () => {
+    const migratedKpiTitles = getMigratedKpiTitles(legacyKpi, {
+      cube,
+      mapping: {
+        columns: [{ type: "allMeasures" }],
+        measures: [{ type: "measure", measureName: "contributors.COUNT" }],
+        rows: [
+          {
+            type: "hierarchy",
+            dimensionName: "Currency",
+            hierarchyName: "Currency",
+            levelName: "Currency",
+          },
+        ],
+      },
+    });
+    expect(migratedKpiTitles).toMatchInlineSnapshot(`
+      {
+        "[Measures].[contributors.COUNT],[Currency].[Currency].[AllMember].[EUR, USD]": "Hello World",
+      }
+    `);
+  });
+});

--- a/src/4.3_to_5.0/getMigratedKpiTitles.test.ts
+++ b/src/4.3_to_5.0/getMigratedKpiTitles.test.ts
@@ -1,15 +1,25 @@
 import { dataModelsForTests } from "@activeviam/data-model-5.0";
 import { getMigratedKpiTitles } from "./getMigratedKpiTitles";
 import { legacyKpi } from "./__test_resources__/legacyKpi";
+import { _getQueryInLegacyWidgetState } from "./_getQueryInLegacyWidgetState";
+import { MdxSelect, parse } from "@activeviam/mdx-5.0";
 
 const cube = dataModelsForTests.sandbox.catalogs[0].cubes[0];
 
 describe("getMigratedKpiTitles", () => {
   it("returns the migrated KPI titles corresponding to the legacy KPI state, ready to be used in Atoti UI 5.0", () => {
+    const legacyQuery = _getQueryInLegacyWidgetState(legacyKpi);
+
+    if (!legacyQuery || !legacyQuery.mdx) {
+      throw new Error("Expected the legacy KPI state to contain a query");
+    }
+
+    const legacyMdx = parse<MdxSelect>(legacyQuery.mdx);
     const migratedKpiTitles = getMigratedKpiTitles(legacyKpi, {
       cube,
+      legacyMdx,
       mapping: {
-        columns: [{ type: "allMeasures" }],
+        columns: [],
         measures: [{ type: "measure", measureName: "contributors.COUNT" }],
         rows: [
           {

--- a/src/4.3_to_5.0/getMigratedKpiTitles.ts
+++ b/src/4.3_to_5.0/getMigratedKpiTitles.ts
@@ -5,7 +5,13 @@ import {
   MdxUnknownCompoundIdentifier,
   parse,
 } from "@activeviam/activeui-sdk-5.0";
-import { getSpecificCompoundIdentifier, quote } from "@activeviam/mdx-5.0";
+import {
+  getSpecificCompoundIdentifier,
+  quote,
+  getMeasuresAxisName,
+  getMeasuresPositionOnAxis,
+  MdxSelect,
+} from "@activeviam/mdx-5.0";
 
 interface LegacyKpiTitle {
   title: string;
@@ -68,24 +74,43 @@ export function getMigratedKpiTitles(
   // Legacy widget states are not typed.
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   legacyKpiState: any,
-  { mapping, cube }: { mapping: DataVisualizationWidgetMapping; cube: Cube },
+  {
+    legacyMdx,
+    mapping,
+    cube,
+  }: {
+    legacyMdx: MdxSelect;
+    mapping: DataVisualizationWidgetMapping;
+    cube: Cube;
+  },
 ): KpiWidgetState["titles"] {
   const legacyTitles = _getLegacyKpiTitles(legacyKpiState, { cube });
   const migratedTitles: KpiWidgetState["titles"] = {};
 
-  const memberUniqueNames: string[] = [];
+  const numberOfColumnFields = mapping.columns?.length ?? 0;
+
+  const measuresAxisName = getMeasuresAxisName(legacyMdx);
+  const measuresAxis = legacyMdx.axes.find(
+    (axis) => axis.name === measuresAxisName,
+  );
+  let measuresPositionInTuple = -1;
+  if (measuresAxis) {
+    const measuresPositionOnAxis = getMeasuresPositionOnAxis(measuresAxis);
+    measuresPositionInTuple = ["0", "COLUMNS"].includes(measuresAxisName)
+      ? measuresPositionOnAxis
+      : numberOfColumnFields + measuresPositionOnAxis;
+  }
+
+  // Atoti UI 5.0 KPI widgets expect tuple keys to express members in the following order:
+  // - column fields first
+  // - then row fields
+  const ordinalFields = [...(mapping.columns ?? []), ...(mapping.rows ?? [])];
+
   legacyTitles.forEach(({ title, tuple }) => {
-    // Atoti UI 5.0 KPI widgets expect tuple keys to express members in the following order:
-    // - column fields first
-    // - then row fields
-    const fields = [...(mapping.columns ?? []), ...(mapping.rows ?? [])];
-    fields.forEach((field) => {
-      if (field.type === "allMeasures") {
-        const measureName = tuple[`[Measures].[Measures]`]?.[0];
-        if (measureName) {
-          memberUniqueNames.push(`[Measures].[${measureName}]`);
-        }
-      } else if (field.type === "hierarchy") {
+    const memberUniqueNames: string[] = [];
+
+    ordinalFields.forEach((field) => {
+      if (field.type === "hierarchy") {
         const hierarchyUniqueName = quote(
           field.dimensionName,
           field.hierarchyName,
@@ -98,6 +123,16 @@ export function getMigratedKpiTitles(
         }
       }
     });
+
+    if (measuresPositionInTuple > -1) {
+      const measureName = tuple[quote("Measures", "Measures")][0];
+      memberUniqueNames.splice(
+        measuresPositionInTuple,
+        0,
+        quote("Measures", measureName),
+      );
+    }
+
     const tupleKey = memberUniqueNames.join(",");
     migratedTitles[tupleKey] = title;
   });

--- a/src/4.3_to_5.0/getMigratedKpiTitles.ts
+++ b/src/4.3_to_5.0/getMigratedKpiTitles.ts
@@ -48,9 +48,11 @@ function _getLegacyKpiTitles(
           specificCompoundIdentifier.measureName,
         ];
       } else if (specificCompoundIdentifier.type === "member") {
-        tuple[
-          `[${specificCompoundIdentifier.dimensionName}].[${specificCompoundIdentifier.hierarchyName}]`
-        ] = specificCompoundIdentifier.path;
+        const hierarchyUniqueName = quote(
+          specificCompoundIdentifier.dimensionName,
+          specificCompoundIdentifier.hierarchyName,
+        );
+        tuple[hierarchyUniqueName] = specificCompoundIdentifier.path;
       }
     }
     legacyTitles.push({ title, tuple });
@@ -84,7 +86,10 @@ export function getMigratedKpiTitles(
           memberUniqueNames.push(`[Measures].[${measureName}]`);
         }
       } else if (field.type === "hierarchy") {
-        const hierarchyUniqueName = `[${field.dimensionName}].[${field.hierarchyName}]`;
+        const hierarchyUniqueName = quote(
+          field.dimensionName,
+          field.hierarchyName,
+        );
         const namePath = tuple[hierarchyUniqueName];
         if (namePath) {
           memberUniqueNames.push(

--- a/src/4.3_to_5.0/getMigratedKpiTitles.ts
+++ b/src/4.3_to_5.0/getMigratedKpiTitles.ts
@@ -1,0 +1,101 @@
+import {
+  Cube,
+  DataVisualizationWidgetMapping,
+  KpiWidgetState,
+  MdxUnknownCompoundIdentifier,
+  parse,
+} from "@activeviam/activeui-sdk-5.0";
+import { getSpecificCompoundIdentifier, quote } from "@activeviam/mdx-5.0";
+
+interface LegacyKpiTitle {
+  title: string;
+  tuple: { [hierarchyUniqueName: string]: string[] };
+}
+
+/**
+ * Returns the legacy KPI titles attached to `legacyKpiState`.
+ */
+function _getLegacyKpiTitles(
+  // Legacy widget states are not typed.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  legacyKpiState: any,
+  { cube }: { cube: Cube },
+): LegacyKpiTitle[] {
+  const locations =
+    legacyKpiState?.value?.body?.configuration?.featuredValues?.locations;
+
+  if (!locations) {
+    return [];
+  }
+
+  const legacyTitles: LegacyKpiTitle[] = [];
+
+  for (const tupleKey in locations) {
+    const { title } = locations[tupleKey];
+    const tuple: {
+      [hierarchyUniqueName: string]: string[];
+    } = {};
+    const memberUniqueNames = tupleKey.split(/,(?![^\[]*\])/);
+    for (const memberUniqueName of memberUniqueNames) {
+      const compoundIdentifier =
+        parse<MdxUnknownCompoundIdentifier>(memberUniqueName);
+      const specificCompoundIdentifier = getSpecificCompoundIdentifier(
+        compoundIdentifier,
+        { cube },
+      );
+      if (specificCompoundIdentifier.type === "measure") {
+        tuple[`[Measures].[Measures]`] = [
+          specificCompoundIdentifier.measureName,
+        ];
+      } else if (specificCompoundIdentifier.type === "member") {
+        tuple[
+          `[${specificCompoundIdentifier.dimensionName}].[${specificCompoundIdentifier.hierarchyName}]`
+        ] = specificCompoundIdentifier.path;
+      }
+    }
+    legacyTitles.push({ title, tuple });
+  }
+
+  return legacyTitles;
+}
+
+/**
+ * Returns the migrated KPI widget titles corresponding to legacyKpiState.
+ */
+export function getMigratedKpiTitles(
+  // Legacy widget states are not typed.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  legacyKpiState: any,
+  { mapping, cube }: { mapping: DataVisualizationWidgetMapping; cube: Cube },
+): KpiWidgetState["titles"] {
+  const legacyTitles = _getLegacyKpiTitles(legacyKpiState, { cube });
+  const migratedTitles: KpiWidgetState["titles"] = {};
+
+  const memberUniqueNames: string[] = [];
+  legacyTitles.forEach(({ title, tuple }) => {
+    // Atoti UI 5.0 KPI widgets expect tuple keys to express members in the following order:
+    // - column fields first
+    // - then row fields
+    const fields = [...(mapping.columns ?? []), ...(mapping.rows ?? [])];
+    fields.forEach((field) => {
+      if (field.type === "allMeasures") {
+        const measureName = tuple[`[Measures].[Measures]`]?.[0];
+        if (measureName) {
+          memberUniqueNames.push(`[Measures].[${measureName}]`);
+        }
+      } else if (field.type === "hierarchy") {
+        const hierarchyUniqueName = `[${field.dimensionName}].[${field.hierarchyName}]`;
+        const namePath = tuple[hierarchyUniqueName];
+        if (namePath) {
+          memberUniqueNames.push(
+            `${hierarchyUniqueName}.${quote(...namePath)}`,
+          );
+        }
+      }
+    });
+    const tupleKey = memberUniqueNames.join(",");
+    migratedTitles[tupleKey] = title;
+  });
+
+  return migratedTitles;
+}

--- a/src/4.3_to_5.0/migrateKpi.test.ts
+++ b/src/4.3_to_5.0/migrateKpi.test.ts
@@ -39,6 +39,9 @@ describe("migrateKpi", () => {
           },
         ],
         "serverKey": "my-server",
+        "titles": {
+          "[Measures].[contributors.COUNT],[Currency].[Currency].[AllMember].[EUR, USD]": "Hello World",
+        },
         "widgetKey": "kpi",
       }
     `);
@@ -81,6 +84,9 @@ describe("migrateKpi", () => {
         },
         "queryContext": [],
         "serverKey": "my-server",
+        "titles": {
+          "[Measures].[pnl.FOREX],[Currency].[Currency].[AllMember].[GBP]": "Hello World",
+        },
         "widgetKey": "kpi",
       }
     `);

--- a/src/4.3_to_5.0/migrateKpi.ts
+++ b/src/4.3_to_5.0/migrateKpi.ts
@@ -23,8 +23,6 @@ import {
 import {
   getSpecificCompoundIdentifier,
   findDescendant,
-  getMeasuresPositionOnAxis,
-  getMeasuresAxisName,
 } from "@activeviam/mdx-5.0";
 import { UnsupportedLegacyQueryUpdateModeError } from "./errors/UnsupportedLegacyQueryUpdateModeError";
 import { _getQueryInLegacyWidgetState } from "./_getQueryInLegacyWidgetState";
@@ -213,36 +211,14 @@ export function migrateKpi(
   };
 
   try {
-    // Migrate manually entered KPI titles.
-    if (mdx && mapping.measures.length > 0) {
-      const measuresAxisName = getMeasuresAxisName(mdx);
-      const measuresAxis = mdx.axes.find(
-        (axis) => axis.name === measuresAxisName,
-      );
-      if (measuresAxis) {
-        const positionOfAllMeasuresWithinAxis =
-          getMeasuresPositionOnAxis(measuresAxis);
-
-        // pluginWidgetKpi has `doesSupportMeasuresRedirection: false`.
-        // For this reason, its "allMeasures" tile is omitted from the mapping generated from `deriveMappingFromMdx`.
-        // But the position of this tile needs to be known here, as the order of the members in the tuple matters for manually entered KPI titles to work in Atoti UI 5.0.
-        const mappingWithAllMeasuresTile = produce(mapping, (draft) => {
-          const attribute = ["ROWS", "1"].includes(measuresAxisName)
-            ? draft.rows
-            : draft.columns;
-          attribute.splice(positionOfAllMeasuresWithinAxis, 0, {
-            type: "allMeasures",
-          });
-        });
-
-        const migratedTitles = getMigratedKpiTitles(legacyKpiState, {
-          cube,
-          mapping: mappingWithAllMeasuresTile,
-        });
-        if (migratedTitles && Object.keys(migratedTitles).length > 0) {
-          migratedWidgetState.titles = migratedTitles;
-        }
-      }
+    if (legacyMdx) {
+      // Migrate manually entered KPI titles.
+      const migratedTitles = getMigratedKpiTitles(legacyKpiState, {
+        cube,
+        mapping,
+        legacyMdx,
+      });
+      migratedWidgetState.titles = migratedTitles;
     }
   } catch (error) {
     // Migrating the KPI titles is a best effort.

--- a/src/4.3_to_5.0/migrateKpi.ts
+++ b/src/4.3_to_5.0/migrateKpi.ts
@@ -218,7 +218,9 @@ export function migrateKpi(
         mapping,
         legacyMdx,
       });
-      migratedWidgetState.titles = migratedTitles;
+      if (migratedTitles && Object.keys(migratedTitles).length > 0) {
+        migratedWidgetState.titles = migratedTitles;
+      }
     }
   } catch (error) {
     // Migrating the KPI titles is a best effort.
@@ -226,6 +228,9 @@ export function migrateKpi(
     throw new PartialMigrationError(
       `Could not migrate the titles of the featured values widget named "${legacyKpiState.name}"`,
       serializeWidgetState(migratedWidgetState),
+      {
+        cause: error,
+      },
     );
   }
 

--- a/src/4.3_to_5.0/migrateKpi.ts
+++ b/src/4.3_to_5.0/migrateKpi.ts
@@ -30,6 +30,7 @@ import { _getTargetCubeFromServerUrl } from "./_getTargetCubeFromServerUrl";
 import { _migrateQuery } from "./_migrateQuery";
 import { produce } from "immer";
 import { getMigratedKpiTitles } from "./getMigratedKpiTitles";
+import { PartialMigrationError } from "../PartialMigrationError";
 
 const moveExpressionToWithClause = (
   draft: any,
@@ -224,9 +225,9 @@ export function migrateKpi(
   } catch (error) {
     // Migrating the KPI titles is a best effort.
     // The migration script should not fail if this part errors.
-    console.warn(
-      `Could not migrate the titles of the featured values widget named "${legacyKpiState.name}". Underlying error:\n`,
-      error,
+    throw new PartialMigrationError(
+      `Could not migrate the titles of the featured values widget named "${legacyKpiState.name}"`,
+      serializeWidgetState(migratedWidgetState),
     );
   }
 

--- a/src/PartialMigrationError.ts
+++ b/src/PartialMigrationError.ts
@@ -10,8 +10,9 @@ export class PartialMigrationError extends Error {
   constructor(
     message: string,
     migratedWidgetState: AWidgetState<"serialized">,
+    options?: ErrorOptions,
   ) {
-    super(message);
+    super(message, options);
     this.migratedWidgetState = migratedWidgetState;
   }
 }


### PR DESCRIPTION
This ensures that KPI titles manually entered by users on Atoti UI 4.3 are still honored when they open their dashboards after a 4.3 -> 5.0 content migration.

![image](https://github.com/activeviam/atoti-ui-migration/assets/5601730/6a66f4a6-9beb-4b59-8893-f55ebefb7910)

The changes might seem bigger than expected. It is because both Atoti UI 4.3 and 5.0 use the unique names of its members in order to identify a tuple, but they don't do it in the same order unfortunately.

Atoti UI 5.0 does:
- fields on columns (including measures if present)
- fields on rows (including measures if present)

Atoti UI 4.3 does:
- fields on rows (including measures if present)
- fields on columns (including measures if present)