### PR TITLE
UI-9526 - Ensures that the `behaviorOnError` flag is respected

### DIFF
--- a/src/4.3_to_5.0/__snapshots__/migrate_43_to_50.test.ts.snap
+++ b/src/4.3_to_5.0/__snapshots__/migrate_43_to_50.test.ts.snap
@@ -1336,7 +1336,7 @@ exports[`migrate_43_to_50 returns a valid ActiveUI5 /ui folder on a real life in
               "entry": {
                 "canRead": true,
                 "canWrite": true,
-                "content": "{}",
+                "content": "{"name":"Page filters","type":"container","value":{"style":{},"showTitleBar":true,"body":{},"containerKey":"filters"}}",
                 "isDirectory": false,
                 "lastEditor": "admin",
                 "owners": [
@@ -1608,7 +1608,7 @@ exports[`migrate_43_to_50 returns a valid ActiveUI5 /ui folder on a real life in
                   "entry": {
                     "canRead": true,
                     "canWrite": true,
-                    "content": "{"name":"Page filters","widgetKey":"filters"}",
+                    "content": "{"name":"Page filters"}",
                     "isDirectory": true,
                     "lastEditor": "admin",
                     "owners": [

--- a/src/4.3_to_5.0/__test_resources__/smallLegacyUIFolderWithInvalidWidget.ts
+++ b/src/4.3_to_5.0/__test_resources__/smallLegacyUIFolderWithInvalidWidget.ts
@@ -1,0 +1,162 @@
+/**
+ * The shortened version of the content of the /ui folder on a Content Server, useful for unit tests.
+ * Contains an invalid widget whose `containerKey` is not valid.
+ */
+export const smallLegacyUIFolderWithInvalidWidget = {
+  entry: {
+    isDirectory: true,
+    owners: ["admin"],
+    readers: ["admin"],
+    timestamp: 1607879725132,
+    lastEditor: "admin",
+    canRead: true,
+    canWrite: true,
+  },
+  children: {
+    bookmarks: {
+      entry: {
+        isDirectory: true,
+        owners: ["ROLE_CS_ROOT"],
+        readers: ["ROLE_USER"],
+        timestamp: 1607879735685,
+        lastEditor: "admin",
+        canRead: true,
+        canWrite: true,
+      },
+      children: {
+        content: {
+          entry: {
+            isDirectory: true,
+            owners: ["ROLE_USER"],
+            readers: ["ROLE_USER"],
+            timestamp: 1607879735685,
+            lastEditor: "admin",
+            canRead: true,
+            canWrite: true,
+          },
+          children: {
+            "158": {
+              entry: {
+                content:
+                  '{"description":"Widget with invalid container key","name":"Invalid widget","type":"container","value":{"style":{},"showTitleBar":false,"containerKey":"invalid-container-key","body":{"serverUrl":"","mdx":"SELECT NON EMPTY [Measures].[contributors.COUNT] ON COLUMNS FROM [EquityDerivativesCube] WHERE [Geography].[City].[ALL].[AllMember].[New York] CELL PROPERTIES VALUE, FORMATTED_VALUE, BACK_COLOR, FORE_COLOR, FONT_FLAGS","contextValues":{},"updateMode":"once","ranges":{}}}}',
+                isDirectory: false,
+                owners: ["admin"],
+                readers: ["admin"],
+                timestamp: 1607879735685,
+                lastEditor: "admin",
+                canRead: true,
+                canWrite: true,
+              },
+            },
+            "777": {
+              entry: {
+                content:
+                  '{"description": "Valid widget","name": "Valid widget","type": "container", "value": {"style": {},"showTitleBar": false,"containerKey": "pivot-table","body": {"serverUrl": "","mdx": "SELECT NON EMPTY [Measures].[contributors.COUNT] ON COLUMNS FROM [EquityDerivativesCube] WHERE [Geography].[City].[ALL].[AllMember].[New York] CELL PROPERTIES VALUE, FORMATTED_VALUE, BACK_COLOR, FORE_COLOR, FONT_FLAGS","contextValues": {},"updateMode": "once", "ranges": {}}}}',
+                isDirectory: false,
+                owners: ["admin"],
+                readers: ["admin"],
+                timestamp: 1607879735685,
+                lastEditor: "admin",
+                canRead: true,
+                canWrite: true,
+              },
+            },
+          },
+        },
+        i18n: {
+          entry: {
+            isDirectory: true,
+            owners: ["ROLE_CS_ROOT"],
+            readers: ["ROLE_USER"],
+            timestamp: 1607879735685,
+            lastEditor: "admin",
+            canRead: true,
+            canWrite: true,
+          },
+          children: {
+            "en-US": {
+              entry: {
+                isDirectory: true,
+                owners: ["ROLE_CS_ROOT"],
+                readers: ["ROLE_USER"],
+                timestamp: 1607879735685,
+                lastEditor: "admin",
+                canRead: true,
+                canWrite: true,
+              },
+            },
+            "fr-FR": {
+              entry: {
+                isDirectory: true,
+                owners: ["ROLE_CS_ROOT"],
+                readers: ["ROLE_USER"],
+                timestamp: 1607879735685,
+                lastEditor: "admin",
+                canRead: true,
+                canWrite: true,
+              },
+            },
+          },
+        },
+        structure: {
+          entry: {
+            isDirectory: true,
+            owners: ["ROLE_USER"],
+            readers: ["ROLE_USER"],
+            timestamp: 1607879735685,
+            lastEditor: "admin",
+            canRead: true,
+            canWrite: true,
+          },
+          children: {
+            "158": {
+              entry: {
+                isDirectory: true,
+                owners: ["admin"],
+                readers: ["admin"],
+                timestamp: 1607879735685,
+                lastEditor: "admin",
+                canRead: true,
+                canWrite: true,
+              },
+            },
+            "777": {
+              entry: {
+                isDirectory: true,
+                owners: ["admin"],
+                readers: ["admin"],
+                timestamp: 1607879735685,
+                lastEditor: "admin",
+                canRead: true,
+                canWrite: true,
+              },
+            },
+          },
+        },
+      },
+    },
+    settings: {
+      entry: {
+        isDirectory: true,
+        owners: ["ROLE_CS_ROOT"],
+        readers: ["ROLE_USER"],
+        timestamp: 1607879735685,
+        lastEditor: "admin",
+        canRead: true,
+        canWrite: true,
+      },
+    },
+    version: {
+      entry: {
+        content: '{"package":"4.3.8","contentServerApi":"0.1.0"}',
+        isDirectory: false,
+        owners: ["ROLE_CS_ROOT"],
+        readers: ["ROLE_USER"],
+        timestamp: 1607879735685,
+        lastEditor: "admin",
+        canRead: true,
+        canWrite: true,
+      },
+    },
+  },
+};

--- a/src/4.3_to_5.0/__test_resources__/smallLegacyUIFolderWithInvalidWidget.ts
+++ b/src/4.3_to_5.0/__test_resources__/smallLegacyUIFolderWithInvalidWidget.ts
@@ -48,6 +48,19 @@ export const smallLegacyUIFolderWithInvalidWidget = {
                 canWrite: true,
               },
             },
+            "1231": {
+              entry: {
+                content:
+                  '{"description":"Widget with filter on invalid hierarchy","name":"Invalid widget","type":"container","value":{"style":{},"showTitleBar":false,"containerKey":"pivot-table","body":{"serverUrl":"","mdx":"SELECT NON EMPTY [Measures].[contributors.COUNT] ON COLUMNS FROM [EquityDerivativesCube] WHERE [Geography].[InvalidHierarchy].[ALL].[AllMember].[Member] CELL PROPERTIES VALUE, FORMATTED_VALUE, BACK_COLOR, FORE_COLOR, FONT_FLAGS","contextValues":{},"updateMode":"once","ranges":{}}}}',
+                isDirectory: false,
+                owners: ["admin"],
+                readers: ["admin"],
+                timestamp: 1607879735685,
+                lastEditor: "admin",
+                canRead: true,
+                canWrite: true,
+              },
+            },
             "777": {
               entry: {
                 content:
@@ -110,6 +123,17 @@ export const smallLegacyUIFolderWithInvalidWidget = {
           },
           children: {
             "158": {
+              entry: {
+                isDirectory: true,
+                owners: ["admin"],
+                readers: ["admin"],
+                timestamp: 1607879735685,
+                lastEditor: "admin",
+                canRead: true,
+                canWrite: true,
+              },
+            },
+            "1231": {
               entry: {
                 isDirectory: true,
                 owners: ["admin"],

--- a/src/4.3_to_5.0/__test_resources__/smallLegacyUIFolderWithInvalidWidget.ts
+++ b/src/4.3_to_5.0/__test_resources__/smallLegacyUIFolderWithInvalidWidget.ts
@@ -1,6 +1,6 @@
 /**
  * The shortened version of the content of the /ui folder on a Content Server, useful for unit tests.
- * Contains an invalid widget whose `containerKey` is not valid.
+ * Contains a widget whose `containerKey` is not valid and another widget with a filter with an invalid hierarchy.
  */
 export const smallLegacyUIFolderWithInvalidWidget = {
   entry: {

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -126,7 +126,7 @@ yargs
           More generically, assuming that the error occurred at step p out of a total of n, you can choose one of the following behaviors:
           \n- "keep-original": keep the original item untouched, as before the whole migration.
           \n- "keep-last-successful-version": keep the version of the item obtained after the first p-1 successful steps.
-          \n- "keep-going": try to apply the n-p remaining steps to the version of the item obtained after step p, despite the error. Note that the remaining steps are likely to fail too, and in that case the result will be the same as "keep-last-succesful-version".
+          \n- "keep-going": try to apply the n-p remaining steps to the version of the item obtained after step p, despite the error. Note that the remaining steps are likely to fail too, and in that case the result will be the same as "keep-last-successful-version".
         `,
       });
       args.implies("stack", "debug");

--- a/src/getMigrateSavedWidgets.ts
+++ b/src/getMigrateSavedWidgets.ts
@@ -68,7 +68,7 @@ export const getMigrateSavedWidgets =
 
     for (const fileId in content.children) {
       if (errorReport.widgets?.[fileId] && behaviorOnError !== "keep-going") {
-        return;
+        continue;
       }
 
       if (!filesAncestry[fileId]) {

--- a/src/migrateContentServer.test.ts
+++ b/src/migrateContentServer.test.ts
@@ -277,7 +277,7 @@ describe("migrateContentServer", () => {
     );
   });
 
-  it("keeps 5.0 version of the widget, when the there is an error when attempting to migrate it from 5.0 to 5.1 when the `behaviorOnError` flag is set to `keep-last-successful-version`.", async () => {
+  it("keeps 5.0 version of the widget, when there is an error when attempting to migrate the widget from 5.0 to 5.1 when the `behaviorOnError` flag is set to `keep-last-successful-version`.", async () => {
     const contentServer: ContentRecord = {
       children: {
         ui: smallLegacyUIFolderWithInvalidWidget,
@@ -294,6 +294,8 @@ describe("migrateContentServer", () => {
       },
     };
 
+    const contentServerBeforeMigration = _cloneDeep(contentServer);
+
     await migrateContentServer({
       contentServer,
       servers,
@@ -304,6 +306,12 @@ describe("migrateContentServer", () => {
       shouldUpdateFiltersMdx: true,
       behaviorOnError: "keep-last-successful-version",
     });
+
+    const savedWidgetContentBeforeMigration =
+      contentServerBeforeMigration.children?.ui.children?.bookmarks.children
+        ?.content.children?.["1231"].entry.content;
+
+    expect(savedWidgetContentBeforeMigration.filters).not.toBeDefined();
 
     const savedWidgetContentAfterMigration = JSON.parse(
       contentServer?.children?.ui?.children?.widgets?.children?.content


### PR DESCRIPTION
## Summary

This PR ensures that when a 4.3 widget is being migrated if it throws an error, it is kept as is and that the remaining widgets are still migrated as expected.

## Testing 
All tests should pass. 