### PR TITLE
UI-10795 - Remove empty layout leaf after removing signoff widgets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,3 +41,4 @@ workflows:
             branches:
               ignore:
                 - main
+                - migrate_signoff_5_to_6

--- a/__mocks__/antd.js
+++ b/__mocks__/antd.js
@@ -18,4 +18,7 @@ module.exports = {
   ConfigProvider: {
     ConfigContext: {},
   },
+  DatePicker: {
+    RangePicker: {},
+  },
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,10 +4,13 @@ const isCI = require("is-ci");
 const extensions = ["js", "jsx", "ts", "tsx", "mjs", "json"];
 const esmPackages = [
   "@activeviam/*",
+  "@ant-design/*",
+  "@babel/runtime",
   "lodash-es",
   "monaco-editor",
   "react-dnd-html5-backend",
   "array-move",
+  "rc-util",
 ];
 
 // Note that in addition to the config below, there are several mocked modules under the __mocks__ folder.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@activeviam/content-server-initialization-5.0": "npm:@activeviam/content-server-initialization@5.0.41",
     "@activeviam/dashboard-base-5.0": "npm:@activeviam/dashboard-base@5.0.41",
     "@activeviam/dashboard-base-5.1": "npm:@activeviam/dashboard-base@5.1.23",
+    "@activeviam/dashboard-base-5.2": "npm:@activeviam/dashboard-base@5.2.4",
     "@activeviam/data-model-5.0": "npm:@activeviam/data-model@5.0.41",
     "@activeviam/data-model-5.1": "npm:@activeviam/data-model@5.1.23",
     "@activeviam/mdx-5.0": "npm:@activeviam/mdx@5.0.41",

--- a/src/migrateContentServer.test.ts
+++ b/src/migrateContentServer.test.ts
@@ -404,7 +404,7 @@ describe("migrateContentServer", () => {
     `);
   });
 
-  it("removes obsolete widgets", async () => {
+  it("removes obsolete signoff widgets", async () => {
     const keysOfWidgetPluginsToRemove = [
       "signoff_adjustments-table",
       "signoff_daily-progress-widget",
@@ -435,5 +435,48 @@ describe("migrateContentServer", () => {
       expect(serializedWidgetContentAndStructure).not.toContain(key);
       expect(serializedDashboardContent).not.toContain(key);
     });
+
+    expect(
+      JSON.parse(
+        signoffBusinessContentServer.children?.ui.children?.dashboards.children
+          ?.content.children["xR07SN"].entry.content,
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "filters": [],
+        "pages": {
+          "p-0": {
+            "content": {
+              "0": {
+                "mapping": {
+                  "columns": [
+                    "ALL_MEASURES",
+                  ],
+                  "measures": [],
+                  "rows": [],
+                },
+                "query": {
+                  "updateMode": "once",
+                },
+                "widgetKey": "pivot-table",
+              },
+            },
+            "layout": {
+              "children": [
+                {
+                  "leafKey": "0",
+                  "size": 1,
+                },
+              ],
+              "direction": "row",
+            },
+            "name": "Page 1",
+          },
+        },
+        "pagesOrder": [
+          "p-0",
+        ],
+      }
+    `);
   });
 });

--- a/src/so-5.x_to_so-6.x/migrate_5.x_to_6.x.ts
+++ b/src/so-5.x_to_so-6.x/migrate_5.x_to_6.x.ts
@@ -1,4 +1,11 @@
-import { ContentRecord, DashboardState } from "@activeviam/activeui-sdk-5.2";
+import type {
+  ContentRecord,
+  DashboardState,
+} from "@activeviam/activeui-sdk-5.2";
+import {
+  _removeWidgetFromPage,
+  getLayoutPath,
+} from "@activeviam/dashboard-base-5.2";
 import { MigrationFunction } from "../migration.types";
 
 /**
@@ -59,7 +66,35 @@ export const migrate_5x_to_6x: MigrationFunction<
       Object.values(dashboardState.pages).forEach((page) => {
         Object.entries(page.content).forEach(([leafKey, widget]) => {
           if (keysOfWidgetPluginsToRemove.includes(widget.widgetKey)) {
-            delete page.content[leafKey];
+            const layoutPath = getLayoutPath(page.layout, leafKey);
+            _removeWidgetFromPage(page, layoutPath, leafKey);
+            const isPageEmpty = Object.keys(page.content).length === 0;
+            // _removeWidgetFromPage puts the page in an incorrect state if the last widget was removed.
+            // A page cannot have no widget, a dashboard cannot have no page.
+            if (isPageEmpty) {
+              page.content = {
+                "0": {
+                  mapping: {
+                    rows: [],
+                    columns: ["ALL_MEASURES"],
+                    measures: [],
+                  },
+                  query: {
+                    updateMode: "once",
+                  },
+                  widgetKey: "pivot-table",
+                },
+              };
+              page.layout = {
+                children: [
+                  {
+                    leafKey: "0",
+                    size: 1,
+                  },
+                ],
+                direction: "row",
+              };
+            }
             counters.widgets.removed++;
           }
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1225,7 +1225,7 @@
     lodash-es "^4.17.21"
     react-reverse-portal "2.0.1"
 
-"@activeviam/dashboard-base@5.2.4":
+"@activeviam/dashboard-base-5.2@npm:@activeviam/dashboard-base@5.2.4", "@activeviam/dashboard-base@5.2.4":
   version "5.2.4"
   resolved "https://activeviam.jfrog.io/artifactory/api/npm/npm-internal/@activeviam/dashboard-base/-/@activeviam/dashboard-base-5.2.4.tgz#da617ae9efa166abda85ee9ff8c8f40bdada7217"
   integrity sha512-EjWbZaZC6v74F9V0zTmv2WblTRzMen/ImQwqGRyL1PvWtpkhDMO4BaS+QSHpqCemTyDtGqFmnqUBNldD1CzjcA==


### PR DESCRIPTION
See ticket.

The previous version of this migration script did not clean up the empty layout leaves which in 5.2 displays as empty docks that cannot be removed.